### PR TITLE
Add Jest testing setup

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "start": "tsx src/index.ts"
+    "start": "tsx src/index.ts",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -20,6 +21,9 @@
   "devDependencies": {
     "@types/node": "^24.0.10",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@types/jest": "^29.5.10",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,0 +1,5 @@
+describe('basic test', () => {
+  it('adds numbers', () => {
+    expect(1 + 1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- install Jest, ts-jest and @types/jest
- add example test
- configure Jest via jest.config.ts
- expose `test` script in package.json

## Testing
- `pnpm test` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_686b7bccbffc83238610a7b0d8c1adf2