### PR TITLE
Fix package.json syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
     "test": "tsx tests/index.test.ts",
-    "customize": "node scripts/customize.mjs"
+    "customize": "node scripts/customize.mjs",
     "release": "standard-version",
     "prepare": "husky install",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write .",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add missing comma after `customize` script
- remove trailing comma after `build` script

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('valid')"`

------
https://chatgpt.com/codex/tasks/task_e_686b8ad543e08323ac9425233f962882