### PR TITLE
Enable ESM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [Node.js](https://nodejs.org/) >= 22
 - [pnpm](https://pnpm.io/) >= 10
+- Project uses ES modules (`type: module`)
 
 ## Available Scripts
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "src/index.ts",
+  "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "sourceMap": true,
     "outDir": "dist",


### PR DESCRIPTION
## Summary
- mark package as an ES module
- set TypeScript to NodeNext module resolution
- mention ESM in the README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686b8e9b45088323975f71eacfb68678