### PR TITLE
Add pnpm check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,19 @@
 
 ## Creating a New Project
 
-1. Clone this repository and install dependencies:
+1. Clone this repository and verify `pnpm` is available:
+   ```bash
+   node scripts/check-pnpm.mjs
+   ```
+2. Install dependencies:
    ```bash
    pnpm install
    ```
-2. Run the customize script with your project name:
+3. Run the customize script with your project name:
    ```bash
    pnpm run customize my-new-app
    ```
-3. Commit the changes and start coding.
+4. Commit the changes and start coding.
 
 ## Release workflow
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepare": "husky install",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write .",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "preinstall": "node ./scripts/check-pnpm.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-pnpm.mjs
+++ b/scripts/check-pnpm.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+
+try {
+  execSync('command -v pnpm', { stdio: 'ignore' });
+} catch {
+  console.error('pnpm is required but was not found. Install it from https://pnpm.io.');
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- check pnpm availability in a new script
- refer to the check in the project setup instructions
- run the check in preinstall

## Testing
- `pnpm lint` *(fails: couldn't find eslint config)*
- `pnpm test`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_686b8e8841ac8323a4a489d2c324e0b7