### PR TITLE
Fix CI workflow warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.4.0
         with:
-          node-version: 22
+          node-version: '22'
+          cache: 'pnpm'
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4.1.0
         with:
-          version: 10.12.4
+          version: '10.12.4'
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
## Summary
- pin action versions in the CI workflow
- enable pnpm cache via setup-node

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ba3b92e948323af218e884b8eecab