### PR TITLE
Fix husky commit message hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx commitlint --edit $1

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,6 @@
-import assert from 'assert';
-
-assert.strictEqual(2 + 2, 4);
-console.log('Tests passed');
+describe('index test', () => {
+  it('adds numbers correctly', () => {
+    expect(2 + 2).toBe(4);
+  });
+});
 


### PR DESCRIPTION
## Summary
- update `.husky/commit-msg` to avoid deprecated husky shim
- convert `tests/index.test.ts` to a Jest test so the suite passes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ba385092c8323adeed5cde46d8e70