### PR TITLE
Explain how to handle pnpm approve-builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@
 2. Run `pnpm release` to update the version and `CHANGELOG.md` based on commit history.
 3. Push the generated tag and updated files: `git push --follow-tags`.
 4. Publish the package if desired: `pnpm publish`.
+
+## Approving dependency build scripts
+
+If `pnpm install` prints a warning about ignored build scripts (for example, `esbuild`), run:
+
+```bash
+pnpm approve-builds
+```
+
+If no packages are listed, the warning can be ignored.


### PR DESCRIPTION
## Summary
- document handling of `pnpm` ignored build scripts

## Testing
- `pnpm rebuild`

------
https://chatgpt.com/codex/tasks/task_e_686bbfa5d1008323818cce28c5aa3480