### PR TITLE
Fix ts-jest config warnings

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,14 +1,18 @@
 import type { Config } from 'jest';
 
 const config: Config = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.tests.json'
-    }
-  }
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.tests.json',
+        useESM: true,
+      },
+    ],
+  },
 };
 
 export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
   },
   "include": ["src"],
   "exclude": ["tests"]


### PR DESCRIPTION
## Summary
- migrate deprecated `ts-jest` config syntax
- enable `isolatedModules` to support NodeNext module kind

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_686bc1eddf3883238d54578b10574ccc