### PR TITLE
Fix Jest config for ESM tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@ import type { Config } from 'jest';
 const config: Config = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
   testMatch: ['**/tests/**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "customize": "node scripts/customize.mjs",
     "release": "standard-version",
     "prepare": "husky",


### PR DESCRIPTION
## Summary
- enable VM modules so Jest can handle ES modules
- treat `.ts` files as ESM in the Jest config

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686c293d4e808323bf52317f9338922d