### PR TITLE
Improve project customization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ A simple template for a quick and convenient jumpstart of your project.
 - `pnpm build` - compile TypeScript sources to `dist`
 - `pnpm lint` - type-check the project
 - `pnpm test` - run the example test suite
-- `pnpm customize <name>` - replace template placeholders with `<name>`
+- `pnpm customize <name> [owner]` - replace template placeholders with `<name>`.
+  If `owner` is provided, the `LICENSE` header will be updated with the
+  specified copyright holder. The year is automatically set to the current one.
 
 ## Creating a New Project
 
@@ -28,9 +30,9 @@ A simple template for a quick and convenient jumpstart of your project.
    ```bash
    pnpm install
    ```
-3. Run the customize script with your project name:
+3. Run the customize script with your project name and optional owner:
    ```bash
-   pnpm run customize my-new-app
+   pnpm run customize my-new-app "Jane Doe"
    ```
 4. Commit the changes and start coding.
 

--- a/scripts/customize.mjs
+++ b/scripts/customize.mjs
@@ -3,8 +3,9 @@ import fs from 'fs';
 import path from 'path';
 
 const newName = process.argv[2];
+const newOwner = process.argv[3] ?? newName;
 if (!newName) {
-  console.error('Usage: pnpm run customize <new-project-name>');
+  console.error('Usage: pnpm run customize <new-project-name> [owner]');
   process.exit(1);
 }
 
@@ -14,6 +15,18 @@ const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 pkg.name = newName;
 if (pkg.repository) delete pkg.repository;
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+// Update LICENSE year and owner
+const licensePath = path.resolve('LICENSE');
+if (fs.existsSync(licensePath)) {
+  const licenseText = fs.readFileSync(licensePath, 'utf8');
+  const year = new Date().getFullYear();
+  const updated = licenseText.replace(
+    /Copyright \(c\) \d{4} .+/,
+    `Copyright (c) ${year} ${newOwner}`,
+  );
+  fs.writeFileSync(licensePath, updated);
+}
 
 // Update README header
 const readmePath = path.resolve('README.md');


### PR DESCRIPTION
## Summary
- enhance `customize.mjs` so it also updates LICENSE year and owner
- document new optional owner argument and behaviour in README

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686c35b464c88323b3078d49211e016a