### PR TITLE
Add installation hint for pnpm checker

### DIFF
--- a/scripts/check-pnpm.mjs
+++ b/scripts/check-pnpm.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// Exits if pnpm is not installed. Install pnpm from https://pnpm.io.
 import { execSync } from 'child_process';
 
 try {


### PR DESCRIPTION
## Summary
- document that the `check-pnpm.mjs` script exits when pnpm is missing and how to install it

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686cf354662c8323a83ff98374162019