### PR TITLE
Add SEA build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A starter template for quickly bootstrapping a Node.js project.
 - `pnpm dev` - start development mode with automatic reload
 - `pnpm start` - run the compiled application
 - `pnpm build` - compile TypeScript sources to `dist`
+- `pnpm build:sea` - compile sources and produce a Single Executable Application (SEA)
 - `pnpm lint` - run ESLint
 - `pnpm test` - run the test suite
 - `pnpm format` - format files with Prettier

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write .",
     "build": "tsc -p tsconfig.json",
-    "preinstall": "node ./scripts/check-pnpm.mjs"
+    "preinstall": "node ./scripts/check-pnpm.mjs",
+    "build:sea": "pnpm build && node --experimental-sea-config sea-config.json"
   },
   "repository": {
     "type": "git",

--- a/sea-config.json
+++ b/sea-config.json
@@ -1,0 +1,3 @@
+{
+  "main": "./dist/index.js"
+}

--- a/tsconfig.sea.json
+++ b/tsconfig.sea.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "NodeNext"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- create `sea-config.json` with entrypoint metadata
- add optional `tsconfig.sea.json`
- add `build:sea` npm script
- document SEA build script in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cfde40a248323bb8e5b04da9a8db3